### PR TITLE
Integrate ChemEquil into project

### DIFF
--- a/yaml-convector-2.0/yaml-convector-2.0/ChemEquil.cpp
+++ b/yaml-convector-2.0/yaml-convector-2.0/ChemEquil.cpp
@@ -7,14 +7,10 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#include "cantera/equil/ChemEquil.h"
-#include "cantera/base/stringUtils.h"
-#include "cantera/equil/MultiPhaseEquil.h"
-#include "cantera/thermo/ThermoPhase.h"
-#include "cantera/base/utilities.h"
-#include "cantera/base/global.h"
+#include "ChemEquil.h"
+#include "include/utils.h"
 
-namespace Cantera
+namespace YamlConvector2
 {
 
 int _equilflag(const char* xy)
@@ -96,9 +92,8 @@ void ChemEquil::initialize(ThermoPhase& s)
                 // print a warning.
                 if (s.atomicWeight(m) > 1.0e-3) {
                     warn_user("ChemEquil::initialize",
-                        "species {} has {} atoms of element {}, "
-                        "but this element is not an electron.",
-                        s.speciesName(k), s.nAtoms(k,m), s.elementName(m));
+                        formatString("species {} has {} atoms of element {}, but this element is not an electron.",
+                                    s.speciesName(k), s.nAtoms(k,m), s.elementName(m)));
                 }
             }
         }
@@ -149,8 +144,8 @@ void ChemEquil::update(const ThermoPhase& s)
             m_elementmolefracs[m] += nAtoms(k,m) * m_molefractions[k];
             if (m_molefractions[k] < 0.0) {
                 throw CanteraError("ChemEquil::update",
-                                   "negative mole fraction for {}: {}",
-                                   s.speciesName(k), m_molefractions[k]);
+                                   formatString("negative mole fraction for {}: {}",
+                                                s.speciesName(k), m_molefractions[k]));
             }
         }
         sum += m_elementmolefracs[m];
@@ -353,16 +348,16 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
         break;
     default:
         throw CanteraError("ChemEquil::equilibrate",
-                           "illegal property pair '{}'", XYstr);
+                           formatString("illegal property pair '{}'", XYstr));
     }
     // If the temperature is one of the specified variables, and
     // it is outside the valid range, throw an exception.
     if (tempFixed) {
         double tfixed = s.temperature();
         if (tfixed > s.maxTemp() + 1.0 || tfixed < s.minTemp() - 1.0) {
-            throw CanteraError("ChemEquil::equilibrate", "Specified temperature"
-                               " ({} K) outside valid range of {} K to {} K\n",
-                               s.temperature(), s.minTemp(), s.maxTemp());
+            throw CanteraError("ChemEquil::equilibrate",
+                formatString("Specified temperature ({} K) outside valid range of {} K to {} K",
+                             s.temperature(), s.minTemp(), s.maxTemp()));
         }
     }
 
@@ -571,8 +566,8 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
             if (s.temperature() > s.maxTemp() + 1.0 ||
                     s.temperature() < s.minTemp() - 1.0) {
                 warn_user("ChemEquil::equilibrate",
-                    "Temperature ({} K) outside valid range of {} K "
-                    "to {} K", s.temperature(), s.minTemp(), s.maxTemp());
+                    formatString("Temperature ({} K) outside valid range of {} K to {} K",
+                                 s.temperature(), s.minTemp(), s.maxTemp()));
             }
             return 0;
         }
@@ -667,7 +662,7 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
     // no convergence
     s.restoreState(state);
     throw CanteraError("ChemEquil::equilibrate",
-                       "no convergence in {} iterations.", options.maxIterations);
+                       formatString("no convergence in {} iterations.", options.maxIterations));
 }
 
 
@@ -1365,4 +1360,4 @@ void ChemEquil::adjustEloc(ThermoPhase& s, vector<double>& elMolesGoal)
     s.getMoleFractions(m_molefractions.data());
 }
 
-} // namespace
+} // namespace YamlConvector2

--- a/yaml-convector-2.0/yaml-convector-2.0/ChemEquil.h
+++ b/yaml-convector-2.0/yaml-convector-2.0/ChemEquil.h
@@ -8,13 +8,16 @@
 #ifndef CT_CHEM_EQUIL_H
 #define CT_CHEM_EQUIL_H
 
-#include "cantera/base/ct_defs.h"
+#include "include/ct_defs.h"
+#include "include/utils.h"
+#include "IdealGasPhase.h"
 
-namespace Cantera
+namespace YamlConvector2
 {
 
 class DenseMatrix;
-class ThermoPhase;
+class IdealGasPhase;
+using ThermoPhase = IdealGasPhase;
 //! map property strings to integers
 int _equilflag(const char* xy);
 

--- a/yaml-convector-2.0/yaml-convector-2.0/IdealGasPhase.cpp
+++ b/yaml-convector-2.0/yaml-convector-2.0/IdealGasPhase.cpp
@@ -98,7 +98,8 @@ namespace YamlConvector2 {
     // IdealGasPhase 实现
 
     IdealGasPhase::IdealGasPhase()
-        : Phase(), m_p0(OneAtm), m_pressure(OneAtm), m_tlast(-1.0) {
+        : Phase(), m_p0(OneAtm), m_pressure(OneAtm), m_tlast(-1.0),
+          m_maxTemp(5000.0), m_minTemp(200.0) {
         setName("IdealGas");
     }
 
@@ -782,6 +783,25 @@ namespace YamlConvector2 {
             // Fallback to equal mole fractions if total pressure is zero
             double equal_frac = 1.0 / nSpecies();
             std::vector<double> X(nSpecies(), equal_frac);
+            setMoleFractions(X.data());
+        }
+    }
+
+    void IdealGasPhase::saveState(std::vector<double>& state) const {
+        state.clear();
+        state.push_back(temperature());
+        state.push_back(pressure());
+        state.insert(state.end(), m_moleFractions.begin(), m_moleFractions.end());
+    }
+
+    void IdealGasPhase::restoreState(const std::vector<double>& state) {
+        if (state.size() >= 2 + nSpecies()) {
+            setTemperature(state[0]);
+            setPressure(state[1]);
+            std::vector<double> X(nSpecies());
+            for (size_t k = 0; k < nSpecies(); ++k) {
+                X[k] = state[2 + k];
+            }
             setMoleFractions(X.data());
         }
     }

--- a/yaml-convector-2.0/yaml-convector-2.0/IdealGasPhase.h
+++ b/yaml-convector-2.0/yaml-convector-2.0/IdealGasPhase.h
@@ -154,6 +154,14 @@ namespace YamlConvector2 {    // 常量定义
         // Chemical equilibrium support
         void setToEquilState(const double* mu_RT);
 
+        // State save/restore used by ChemEquil
+        void saveState(std::vector<double>& state) const;
+        void restoreState(const std::vector<double>& state);
+
+        // Temperature limits
+        double maxTemp() const { return m_maxTemp; }
+        double minTemp() const { return m_minTemp; }
+
         // 获取参考状态压力
         double refPressure() const { return m_p0; }
 
@@ -246,6 +254,9 @@ namespace YamlConvector2 {    // 常量定义
         mutable std::vector<double> m_cp0_R;        // 无量纲参考热容
         mutable std::vector<double> m_g0_RT;        // 无量纲参考吉布斯能
         mutable double m_tlast;                     // 上次计算的温度
+
+        double m_maxTemp;                           // Maximum valid temperature
+        double m_minTemp;                           // Minimum valid temperature
 
         // 内部辅助函数
         void parseComposition(const std::string& comp, std::vector<double>& fractions, bool isMass = false);

--- a/yaml-convector-2.0/yaml-convector-2.0/include/ct_defs.h
+++ b/yaml-convector-2.0/yaml-convector-2.0/include/ct_defs.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstddef>
+namespace YamlConvector2 {
+    constexpr std::size_t npos = static_cast<std::size_t>(-1);
+    enum PropertyPair {
+        TP, TV, HP, UV, SP, SV, UP, PT, PH, PS, VT, VU
+    };
+}

--- a/yaml-convector-2.0/yaml-convector-2.0/include/utils.h
+++ b/yaml-convector-2.0/yaml-convector-2.0/include/utils.h
@@ -1,0 +1,118 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <stdexcept>
+#include <iostream>
+#include <sstream>
+#include <cmath>
+#include <cstdarg>
+
+namespace YamlConvector2 {
+
+inline std::string formatString(const std::string& fmt) {
+    return fmt;
+}
+
+template <typename T, typename... Args>
+std::string formatString(const std::string& fmt, T value, Args... args) {
+    std::ostringstream out;
+    std::size_t pos = fmt.find("{}");
+    if (pos == std::string::npos) {
+        return fmt; // nothing to format
+    }
+    out << fmt.substr(0, pos);
+    out << value;
+    out << formatString(fmt.substr(pos + 2), args...);
+    return out.str();
+}
+
+class CanteraError : public std::runtime_error {
+public:
+    CanteraError(const std::string& origin, const std::string& msg)
+        : std::runtime_error(origin + ": " + msg), m_msg(origin + ": " + msg) {}
+    const std::string& getMessage() const { return m_msg; }
+private:
+    std::string m_msg;
+};
+
+template <typename... Args>
+inline void warn_user(const std::string& origin, const std::string& fmt, Args... args) {
+    std::cerr << "Warning [" << origin << "]: " << formatString(fmt, args...) << std::endl;
+}
+
+inline void writelog(const std::string& msg) {
+    std::cout << msg;
+}
+
+template <typename... Args>
+inline void writelogf(const char* fmt, Args... args) {
+    std::printf(fmt, args...);
+}
+
+class DenseMatrix {
+public:
+    DenseMatrix() : m_rows(0), m_cols(0) {}
+    DenseMatrix(std::size_t r, std::size_t c, double val=0.0) { resize(r,c,val); }
+    void resize(std::size_t r, std::size_t c, double val=0.0) {
+        m_rows = r; m_cols = c; m_data.assign(r*c, val);
+    }
+    double& operator()(std::size_t i, std::size_t j) { return m_data[i*m_cols + j]; }
+    double operator()(std::size_t i, std::size_t j) const { return m_data[i*m_cols + j]; }
+    std::size_t nRows() const { return m_rows; }
+    std::size_t nCols() const { return m_cols; }
+private:
+    std::size_t m_rows, m_cols;
+    std::vector<double> m_data;
+};
+
+inline int solve(DenseMatrix& A, double* b) {
+    std::size_t n = A.nRows();
+    for (std::size_t i=0;i<n;i++) {
+        // pivot
+        std::size_t piv = i;
+        double maxVal = std::fabs(A(i,i));
+        for (std::size_t k=i+1;k<n;k++) {
+            if (std::fabs(A(k,i)) > maxVal) { piv = k; maxVal = std::fabs(A(k,i)); }
+        }
+        if (maxVal < 1e-300) return -1;
+        if (piv != i) {
+            for (std::size_t j=0;j<n;j++) std::swap(A(i,j), A(piv,j));
+            std::swap(b[i], b[piv]);
+        }
+        double diag = A(i,i);
+        for (std::size_t j=i;j<n;j++) A(i,j) /= diag;
+        b[i] /= diag;
+        for (std::size_t k=i+1;k<n;k++) {
+            double factor = A(k,i);
+            for (std::size_t j=i;j<n;j++) A(k,j) -= factor*A(i,j);
+            b[k] -= factor*b[i];
+        }
+    }
+    for (int i=n-1; i>=0; --i) {
+        for (int k=0; k<i; ++k) {
+            double factor = A(k,i);
+            A(k,i) = 0.0;
+            b[k] -= factor*b[i];
+        }
+    }
+    return 0;
+}
+
+template<typename Iter1, typename Iter2>
+inline double dot(Iter1 a_begin, Iter1 a_end, Iter2 b_begin) {
+    double sum = 0.0;
+    while (a_begin != a_end) {
+        sum += (*a_begin) * (*b_begin);
+        ++a_begin; ++b_begin;
+    }
+    return sum;
+}
+
+template<typename InIt, typename OutIt>
+inline void scale(InIt first, InIt last, OutIt result, double a) {
+    for (; first != last; ++first, ++result) {
+        *result = (*first) * a;
+    }
+}
+
+} // namespace YamlConvector2


### PR DESCRIPTION
## Summary
- add utility headers with common functions and dense matrix implementation
- adapt `ChemEquil` to use local utilities and namespace
- extend `IdealGasPhase` with equilibrium helper methods

## Testing
- `g++ -std=c++17 -Iyaml-convector-2.0/yaml-convector-2.0 -Iyaml-convector-2.0/yaml-convector-2.0/include yaml-convector-2.0/yaml-convector-2.0/test_compile.cpp yaml-convector-2.0/yaml-convector-2.0/ChemEquil.cpp yaml-convector-2.0/yaml-convector-2.0/IdealGasPhase.cpp yaml-convector-2.0/yaml-convector-2.0/ChemistryIO.cpp yaml-convector-2.0/yaml-convector-2.0/ChemistryVars.cpp -lyaml-cpp -o test_prog` *(fails: vector not declared)*

------
https://chatgpt.com/codex/tasks/task_e_684002108e448329bad1b1b0810f4671