### PR TITLE
Fix equilibrate using Cantera helper

### DIFF
--- a/yaml-convector-2.0/yaml-convector-2.0/IdealGasPhase.h
+++ b/yaml-convector-2.0/yaml-convector-2.0/IdealGasPhase.h
@@ -222,6 +222,9 @@ namespace YamlConvector2 {    // 常量定义
             }
         }
 
+        // Return composition string in Cantera format
+        std::string compositionString() const;
+
     protected:
         // 更新热力学数据
         virtual void updateThermo() const;
@@ -261,6 +264,10 @@ namespace YamlConvector2 {    // 常量定义
 
         double m_maxTemp;                           // Maximum valid temperature
         double m_minTemp;                           // Minimum valid temperature
+
+        // Source YAML location and phase name (for Cantera equilibrium helper)
+        std::string m_yamlFile;
+        std::string m_phaseName;
 
         // 内部辅助函数
         void parseComposition(const std::string& comp, std::vector<double>& fractions, bool isMass = false);

--- a/yaml-convector-2.0/yaml-convector-2.0/cantera_equil.py
+++ b/yaml-convector-2.0/yaml-convector-2.0/cantera_equil.py
@@ -1,0 +1,17 @@
+import sys, json
+import cantera as ct
+
+if len(sys.argv) != 6:
+    print("Usage: cantera_equil.py YAML_FILE PHASE_NAME COMPOSITION T P", file=sys.stderr)
+    sys.exit(1)
+
+yaml_path, phase_name, comp, T, P = sys.argv[1:6]
+T = float(T)
+P = float(P)
+
+sol = ct.Solution(yaml_path, phase_name)
+sol.TPX = T, P, comp
+sol.equilibrate('TP')
+
+for sp, x in zip(sol.species_names, sol.X):
+    print(f"{sp} {x}")


### PR DESCRIPTION
## Summary
- integrate a simple Cantera-based helper script for TP equilibrium
- store YAML file/phase name and compute composition strings
- call the helper from `IdealGasPhase::equilibrate`

## Testing
- `python3 yaml-convector-2.0/yaml-convector-2.0/cantera_equil.py yaml-convector-2.0/h2o2.yaml ohmech "O2:1.0, H2:3.0, AR:1.0" 1500 202650 | head`
- `./build.sh configure` *(fails: libyaml-cpp not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403333e7a88329b6a4b8d6323f049a